### PR TITLE
chore: refactor the TDX-base image dependencies

### DIFF
--- a/setup
+++ b/setup
@@ -28,13 +28,7 @@ source oe-init-build-env
 verbose_output "Sourced the oe-init-build-env script"
 
 # Add the  meta-evm, meta-confidential-compute, meta-secure-core/meta-tpm2, meta-openembedded/meta-python, meta-openembedded/meta-oe layers meta-rust-bin meta-clang to bblayers.conf
-bitbake-layers add-layer ../meta-evm
 bitbake-layers add-layer ../meta-confidential-compute
-bitbake-layers add-layer ../meta-openembedded/meta-oe
-bitbake-layers add-layer ../meta-openembedded/meta-python
-bitbake-layers add-layer ../meta-secure-core/meta-tpm2
-bitbake-layers add-layer ../meta-rust-bin
-bitbake-layers add-layer ../meta-clang
 
 verbose_output "Added the meta-evm and meta-confidential-compute layers to bblayers.conf"
 


### PR DESCRIPTION
This PR cleans up the base TDX yocto image without any dependencies